### PR TITLE
Removed sneaky semicolon

### DIFF
--- a/resources/views/project/create.blade.php
+++ b/resources/views/project/create.blade.php
@@ -34,7 +34,7 @@
 			<div class="card bg-transparent">
 		  		<div class="card-block">
 		    		<!-- Form Post Project -->
-		    		@include('project.form');
+		    		@include('project.form')
 		  		</div>
 			</div>
 		</div>


### PR DESCRIPTION
I found an unused character and thought it might be good to eliminate it :smiling_imp: 

![image](https://user-images.githubusercontent.com/19786918/66193155-ff3d4d80-e65f-11e9-9e13-613409793158.png)

^^^^^
This is the sneaky semicolon. :P