### PR TITLE
Fixed messy forms on project-create page

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -163,7 +163,6 @@
   background-color: transparent;
   border-color: #ffffff;
   color: #ffffff;
-  height: 45px;
 }
 
 option {


### PR DESCRIPTION
I want to fix the messy part on the form shown below since `textarea` should look more extensive.

![image](https://user-images.githubusercontent.com/19786918/66194997-b25b7600-e663-11e9-8d6f-3bd07735b85e.png)

---

This is the result after some changes I made.

![image](https://user-images.githubusercontent.com/19786918/66195023-c30bec00-e663-11e9-8dea-0f514cf6e10c.png)

